### PR TITLE
Add metadata support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v1.4.3
+  - Move to github
+  - Add additional metadata input to support passing complex information to instances (and Ansible) through terraform.
+    Note that "groups" key is reserved and will be overwritten by the `tags` input variable which is used to define inventory groups.
 # v1.4.2
   - Replace deprecated template_file data source usage with templatefile function
   - Remove userdata_vars input restriction

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,12 @@ data "template_cloudinit_config" "cloudinit" {
   }
 }
 
+
+locals {
+  groups   = var.tag != null ? { groups = var.tag } : {}
+  metadata = var.metadata == null ? {} : var.metadata
+}
+
 resource "openstack_compute_instance_v2" "server" {
   name        = var.hostname
   flavor_name = var.flavor
@@ -56,9 +62,7 @@ resource "openstack_compute_instance_v2" "server" {
   user_data    = var.userdatafile == null ? null : data.template_cloudinit_config.cloudinit[0].rendered
   config_drive = var.config_drive
 
-  metadata = {
-    groups = var.tag
-  }
+  metadata = merge(local.metadata, local.groups)
 
   block_device {
     uuid                  = can(regex(local.is_uuid, var.image)) && var.allow_image_uuid ? var.image : data.openstack_images_image_v2.image[0].id

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,12 @@ variable "tag" {
   default     = null
 }
 
+variable "metadata" {
+  type        = map(string)
+  description = "The metadata values to assign to the instance"
+  default     = {}
+}
+
 variable "hostname" {
   type        = string
   description = "hostname"


### PR DESCRIPTION
This PR adds support for configuring additional metadata variables for instances.
The metadata can be used to pass extra information to instances (or indirectly to Ansible) through these metadata values.
Complex values have to be json encoded as only string values are supported for metadata keys.