### PR TITLE
Update network handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+
+# v1.5.0
+
+  - Remove `ext_nets` option for "name" only external networks
+  - Add `networks` input var mirroring `additional_networks`,
+    but adding ports as part of instance instead of attaching them.
+    Also has an additional config field `access` for setting the `access_network` value.
+  - Add `networks` output containing all ports created based on the `networks` input var
+    (same as the `additional_networks` output).
 # v1.4.4
   - Add ext_nets variable to assign an external network via dynmaic block
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Creates a virtual machine without portsec enabled. If you need a need a counter, please use "[terraform-openstack-srv_noportsec-count](https://github.com/ait-cs-IaaS/terraform-openstack-srv_noportsec-count)" instead.
 
-This module allows you to input image, network and subnet (including as part of the additional_networks map) configurations
+This module allows you to input image, network and subnet (including as part of the networks and additional_networks maps) configurations
 either as name or UUIDs. UUIDs will be used directly as input for the underlying resources and names will first be resolved to UUIDs
 using data sources. UUIDs are identified using a regular expression meaning that names which are UUID strings will not be recognized as names. This feature can be disabled using by setting the following boolean flags to `false`:
 
@@ -12,10 +12,19 @@ using data sources. UUIDs are identified using a regular expression meaning that
 
 Once disabled all input for the input type (e.g., network) will be considered to be names regardless of the UUID regular expression.
 
+Networks configured via the `networks` input are considered as inherent parts of the created server instances.
+Thus any configuration changes resulting in the removal or addition of new ports (created from `networks`) will also
+force the recreation of the server instance. In contrast networks configured via `additional_networks` are attached
+to server instances after they have been created. The relationship between the two is thus weaker, meaning removal and
+addition of new `additional_networks` do not result in the recreation of the server instance. They just attach or detach
+the created network ports. Note that this also means networks configured through the `additional_networks` input cannot
+be guaranteed to be available during the instance boot (i.e., cloud-init). Thus brining the resulting network interfaces
+online in the operating system layer and configuring them must be handled separately from the terraform provisioning.
+
 **Note that for the image input it is not possible to use outputs from resources to assign a value to the input (e.g., using an image resources and then referencing the resulting id). Doing so will result in an error and planning/applying will only be possible after the referenced resource has been deployed using the terraform `-target`
 option.**
 
-## Configuration V
+## Configuration
 
 ### Simple Instance with fixed ip
 ```
@@ -49,11 +58,12 @@ module "datenverarbeitung" {
   subnet = var.subnet
   host_address_index = var.host_address_index
   userdatafile = "${path.module}/scripts/default.yml"
-  additional_networks = {
+  networks = {
     second_network = {
       network = var.network_2
       subnet = var.subnet_2
       host_address_index = var.host_address_index2
+      access = null
     }
   }
 }
@@ -73,13 +83,47 @@ module "example" {
   network = "62e04be3-641f-4abe-88d6-87f397a31d7e"
   subnet = "a4c9f461-7c1e-4666-8d0f-4f0ae6404483"
   userdatafile = "${path.module}/scripts/default.yml"
-  additional_networks = {
+  networks = {
     id_input = {
       network = "62e04be3-641f-4abe-88d6-87f397a31d7e"
       subnet = "a4c9f461-7c1e-4666-8d0f-4f0ae6404483"
       host_address_index = null
+      access = null
     }
 
+    name_input = {
+      network = "cyberrange-public"
+      subnet = "cyberrange-public-4"
+      host_address_index = null
+      access = null
+    }
+  }
+}
+```
+
+### Use both networks and additional_networks
+
+```
+module "example" {
+  source = "git@github.com:ait-cs-IaaS/terraform-openstack-srv_noportsec.git"
+  hostname = "example"
+  host_address_index = null
+  image = var.image
+  flavor = var.flavor
+  config_drive = var.config_drive
+  sshkey = var.sshkey
+  network = "62e04be3-641f-4abe-88d6-87f397a31d7e"
+  subnet = "a4c9f461-7c1e-4666-8d0f-4f0ae6404483"
+  userdatafile = "${path.module}/scripts/default.yml"
+  networks = {
+    id_input = {
+      network = "62e04be3-641f-4abe-88d6-87f397a31d7e"
+      subnet = "a4c9f461-7c1e-4666-8d0f-4f0ae6404483"
+      host_address_index = null
+      access = null
+    }
+  }
+  additional_networks = {
     name_input = {
       network = "cyberrange-public"
       subnet = "cyberrange-public-4"

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,13 @@ output "server" {
   sensitive = true
 }
 
+output "networks" {
+  value = {
+    for name, port in openstack_networking_port_v2.ports :
+    name => port
+  }
+}
+
 output "additional_networks" {
   value = {
     for name, port in openstack_networking_port_v2.additional_port :

--- a/variables.tf
+++ b/variables.tf
@@ -60,8 +60,27 @@ variable "host_address_index" {
   default     = null
 }
 
-# the attributes in the additional_networks map behave the same as their default network counter parts 
+variable "network_access" {
+  type        = bool
+  description = "If the main network should be the access_network"
+  default     = false
+}
+
+# the attributes in the networks and additional_networks maps behave the same as their default network counter parts 
 # (e.g., network can be either the name or id)
+variable "networks" {
+  type = map(
+    object({
+      network            = string
+      subnet             = string
+      host_address_index = number
+      access             = bool
+    })
+  )
+  description = "Networks the instance should be created with"
+  default     = {}
+}
+
 variable "additional_networks" {
   type = map(
     object({
@@ -70,7 +89,7 @@ variable "additional_networks" {
       host_address_index = number
     })
   )
-  description = "Additional networks instances should be connected to"
+  description = "Additional networks that should be attached to the instance"
   default     = {}
 }
 
@@ -108,21 +127,3 @@ variable "use_volume" {
   description = "If the a volume or a local file should be used for storage"
   default     = false
 }
-
-variable "network_access" {
-  type        = bool
-  description = "If the main network should be the access_network"
-  default     = false
-}
-
-variable "ext_networks" {
-  type        = set(
-    object({
-      name    = string
-      access  = bool
-    })
-  )
-  description = "External Network Host is Connected to"
-  default     = []
-}
-


### PR DESCRIPTION
Fixes #2 

Note that it is suggested to bump the version of the module to `1.5.0` due to the introduced breaking changes.
Also all upstream modules using this module as base should also be updated to track the new input variable changes (e.g., https://github.com/ait-cs-IaaS/terraform-openstack-srv_noportsec-count)

## Changes

- Remove `ext_nets` option for "name" only external networks *\*breaking\**
- Add `networks` input var mirroring `additional_networks`,
    but adding ports as part of instance instead of attaching them.
    Also has an additional config field `access` for setting the `access_network` value.
- Add `networks` output containing all ports created based on the `networks` input var
    (same as the `additional_networks` output).


## Make sure to check points below to increase likelyhood of your pull request being accepted:

- [x] I have updated the documentation
- [ ] I have added tests to cover my changes
- [x] I checked if all new and existing tests passed
- [x] I checked if I followed standards for style and code quality
- [x] I created an Issue describeing why this change is necessary
