### PR TITLE
DHCP option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ module "datenverarbeitung" {
 
 ```
 
-### Dual-Homed Instance Instance
+### Dual-Homed Instance Instance with DHCP on all networks
 
 ```terraform
 module "datenverarbeitung" {
@@ -62,6 +62,7 @@ module "datenverarbeitung" {
   sshkey = var.sshkey
   network = var.network
   subnet = var.subnet
+  assign_fixed_ip = false
   host_address_index = var.host_address_index
   userdatafile = "${path.module}/scripts/default.yml"
   networks = {
@@ -69,6 +70,7 @@ module "datenverarbeitung" {
       network = var.network_2
       subnet = var.subnet_2
       host_address_index = var.host_address_index2
+      assign_fixed_ip = false
       access = null
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ resource "openstack_networking_port_v2" "port" {
   port_security_enabled = false # default?
   dynamic "fixed_ip" {
     for_each = var.assign_fixed_ip ? [1] : []
-    content = {
+    content {
       subnet_id  = var.subnet_id
       ip_address = cidrhost(var.cidr, var.host_index)
     }
@@ -23,7 +23,7 @@ resource "openstack_networking_port_v2" "ports" {
   dynamic "fixed_ip" {
     iterator = "fixed_ip_each"
     for_each = each.value.assign_fixed_ip == null || each.value.assign_fixed_ip ? [1] : []
-    content = {
+    content {
       subnet_id = each.value.subnet_id
       # if host_index is set within the addional_networks object, then use it (each.value.host_index). otherwise use the parent host index (var.host_index)
       # #coalesce: returns first value, that is not null or "" --> https://developer.hashicorp.com/terraform/language/functions/coalesce

--- a/main.tf
+++ b/main.tf
@@ -1,39 +1,46 @@
 # Create port in the parent network
 resource "openstack_networking_port_v2" "port" {
-  name = "port_${var.name}"
-  network_id = var.network_id
-  admin_state_up = true # default?
+  name                  = "port_${var.name}"
+  network_id            = var.network_id
+  admin_state_up        = true  # default?
   port_security_enabled = false # default?
-  fixed_ip {
-    subnet_id = var.subnet_id
-    ip_address = cidrhost(var.cidr, var.host_index)
+  dynamic "fixed_ip" {
+    for_each = var.assign_fixed_ip ? [1] : []
+    content = {
+      subnet_id  = var.subnet_id
+      ip_address = cidrhost(var.cidr, var.host_index)
+    }
   }
 }
 
 # Create ports in child network(s)
 resource "openstack_networking_port_v2" "ports" {
-  for_each = var.additional_networks
-  name = "port_${var.name}"
-  network_id = each.value.network_id
-  admin_state_up = true # default?
+  for_each              = var.additional_networks
+  name                  = "port_${var.name}"
+  network_id            = each.value.network_id
+  admin_state_up        = true  # default?
   port_security_enabled = false # default?
-  fixed_ip {
-    subnet_id = each.value.subnet_id
-    # if host_index is set within the addional_networks object, then use it (each.value.host_index). otherwise use the parent host index (var.host_index)
-    # #coalesce: returns first value, that is not null or "" --> https://developer.hashicorp.com/terraform/language/functions/coalesce
-    ip_address = cidrhost(each.value.cidr, coalesce(each.value.host_index, var.host_index)) 
+  dynamic "fixed_ip" {
+    iterator = "fixed_ip_each"
+    for_each = each.value.assign_fixed_ip == null || each.value.assign_fixed_ip ? [1] : []
+    content = {
+      subnet_id = each.value.subnet_id
+      # if host_index is set within the addional_networks object, then use it (each.value.host_index). otherwise use the parent host index (var.host_index)
+      # #coalesce: returns first value, that is not null or "" --> https://developer.hashicorp.com/terraform/language/functions/coalesce
+      ip_address = cidrhost(each.value.cidr, coalesce(each.value.host_index, var.host_index))
+    }
   }
 }
 
 # Create instance and assign it to the created ports
 resource "openstack_compute_instance_v2" "server" {
-  name              = var.name
-  image_name        = var.image
-  flavor_name       = var.flavor
-  key_pair          = "cyberrange-key" # it should always be the same (I think there is no need to make that dynamic - 10/04/2024)
-  security_groups   = []
-  user_data         = var.userdata == null ? file("${path.module}/scripts/default.yml") : var.userdata # if no userdata is passed, use the default-file, otherwise use the passed userdata
-  metadata          = local.metadata
+  name            = var.name
+  image_name      = var.image
+  flavor_name     = var.flavor
+  key_pair        = "cyberrange-key" # it should always be the same (I think there is no need to make that dynamic - 10/04/2024)
+  security_groups = []
+  user_data       = var.userdata == null ? file("${path.module}/scripts/default.yml") : var.userdata # if no userdata is passed, use the default-file, otherwise use the passed userdata
+  metadata        = local.metadata
 
   # Assign instance to parent network port
   network { port = openstack_networking_port_v2.port.id }
@@ -57,5 +64,5 @@ resource "openstack_networking_floatingip_v2" "fip" {
 resource "openstack_networking_floatingip_associate_v2" "fip" {
   count       = var.floating_ip ? 1 : 0
   floating_ip = openstack_networking_floatingip_v2.fip[0].address
-  port_id = openstack_networking_port_v2.port.id
+  port_id     = openstack_networking_port_v2.port.id
 }

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "openstack_networking_port_v2" "ports" {
   admin_state_up        = true  # default?
   port_security_enabled = false # default?
   dynamic "fixed_ip" {
-    iterator = "fixed_ip_each"
+    iterator = fixed_ip_each
     for_each = each.value.assign_fixed_ip == null || each.value.assign_fixed_ip ? [1] : []
     content {
       subnet_id = each.value.subnet_id

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,7 @@ variable additional_networks {
       host_index = optional(string) # this is an optional parameter.
       network_id  = string
       subnet_id  = string
+      assign_fixed_ip = optional(bool)
     })
   )
   default = {}
@@ -42,4 +43,9 @@ variable "metadata_groups" {
 variable "metadata_company_info" {
   type = string
   default = ""
+}
+
+variable "assign_fixed_ip" {
+  type = bool
+  default = true
 }


### PR DESCRIPTION
Add an option called `assign_fixed_ip` to control whether to use DHCP or not. The default value is `true` which ensures that existing terraform modules do not break.